### PR TITLE
doc: fix path to gstreamer-setupvars.sh

### DIFF
--- a/docs/source/get_started/install/install_guide_ubuntu.rst
+++ b/docs/source/get_started/install/install_guide_ubuntu.rst
@@ -458,7 +458,7 @@ With all dependencies installed, proceed to build Intel® DL Streamer:
    # OpenVINO™ Toolkit environment
    source /opt/intel/openvino_2022/setupvars.sh
    # GStreamer environment
-   source /opt/intel/dlstreamer/gstreamer/gstreamer-setupvars.sh
+   source /opt/intel/dlstreamer/gstreamer/setupvars.sh
    # Intel® oneAPI DPC++/C++ Compiler environment (if installed)
    # source /opt/intel/oneapi/compiler/latest/env/vars.sh
 

--- a/docs/source/get_started/install/install_guide_ubuntu.rst
+++ b/docs/source/get_started/install/install_guide_ubuntu.rst
@@ -458,7 +458,7 @@ With all dependencies installed, proceed to build Intel® DL Streamer:
    # OpenVINO™ Toolkit environment
    source /opt/intel/openvino_2022/setupvars.sh
    # GStreamer environment
-   source /opt/intel/dlstreamer/gstreamer/bin/gstreamer-setupvars.sh
+   source /opt/intel/dlstreamer/gstreamer/gstreamer-setupvars.sh
    # Intel® oneAPI DPC++/C++ Compiler environment (if installed)
    # source /opt/intel/oneapi/compiler/latest/env/vars.sh
 


### PR DESCRIPTION
Updates install guide for Ubuntu to reflect correct path.

This may need to be applied in other places (e.g. wiki), but not clear that reflects current release.