### PR TITLE
Fix build on GStreamer 1.16

### DIFF
--- a/src/gst/meta_aggregate/meta_aggregate.cpp
+++ b/src/gst/meta_aggregate/meta_aggregate.cpp
@@ -493,7 +493,7 @@ gboolean MetaAggregatePrivate::sinkEvent(GstAggregatorPad *pad, GstEvent *event)
         break;
     }
 
-#if (GST_VERSION_MAJOR >= 1) && (GST_VERSION_MINOR >= 18)
+#if GST_CHECK_VERSION(1, 18, 0)
     /* It is needed, otherwise timestamps might be incorrect */
     // gst_aggregator_update_segment is available starting from 1.18
     case GST_EVENT_SEGMENT: {

--- a/src/gst/meta_aggregate/meta_aggregate.cpp
+++ b/src/gst/meta_aggregate/meta_aggregate.cpp
@@ -493,9 +493,9 @@ gboolean MetaAggregatePrivate::sinkEvent(GstAggregatorPad *pad, GstEvent *event)
         break;
     }
 
+#if (GST_VERSION_MAJOR >= 1) && (GST_VERSION_MINOR >= 18)
     /* It is needed, otherwise timestamps might be incorrect */
     // gst_aggregator_update_segment is available starting from 1.18
-#if 1
     case GST_EVENT_SEGMENT: {
         if (strcmp(GST_OBJECT_NAME(pad), "sink") == 0) {
             const GstSegment *segment;
@@ -608,8 +608,6 @@ static void meta_aggregate_class_init(MetaAggregateClass *klass) {
                                              const GstCaps *caps) {
         return GST_META_AGGREGATE(aggregator)->impl->createNewPad(templ, req_name, caps);
     };
-
-    gstaggregator_class->negotiate = NULL;
 
     // gstaggregator_class->flush = GST_DEBUG_FUNCPTR(metaaggregate_flush);
     // gstaggregator_class->get_next_time = GST_DEBUG_FUNCPTR(metaaggregate_get_next_time);


### PR DESCRIPTION
Note that VAAPI-based pre-processing will not work on gst 1.16, other features should work (but not validated)