### PR TITLE
fix: latency_tracer segfault on elements not created

### DIFF
--- a/src/gst/tracers/latency_tracer/latency_tracer.cpp
+++ b/src/gst/tracers/latency_tracer/latency_tracer.cpp
@@ -323,8 +323,10 @@ static void do_push_buffer_pre(LatencyTracer *lt, guint64 ts, GstPad *pad, GstBu
     }
     if (lt->flags & LATENCY_TRACER_FLAG_ELEMENT) {
         ElementStats *stats = ElementStats::from_element(elem);
-        stats->cal_log_element_latency(ts, meta->last_pad_push_ts, lt->interval);
-        meta->last_pad_push_ts = ts;
+        if (stats != nullptr) {
+            stats->cal_log_element_latency(ts, meta->last_pad_push_ts, lt->interval);
+            meta->last_pad_push_ts = ts;
+        }
     }
     if (lt->flags & LATENCY_TRACER_FLAG_PIPELINE && lt->sink_element == get_real_pad_parent(GST_PAD_PEER(pad))) {
         cal_log_pipeline_latency(lt, ts, meta);


### PR DESCRIPTION
I was getting a segfault while using this tracer on some pipelines involving webrtc plugins. I don't fully understand the element/pad calls and if this is just patching over another issue, but this stops it from segfaulting.