### PR TITLE
Fix Type Mismatch in decode_inference.cpp

### DIFF
--- a/samples/ffmpeg_openvino/cpp/decode_inference/decode_inference.cpp
+++ b/samples/ffmpeg_openvino/cpp/decode_inference/decode_inference.cpp
@@ -77,7 +77,7 @@ int main(int argc, char *argv[]) {
         AVInputFormat *input_format = NULL;
         AVFormatContext *input_ctx = NULL;
         DLS_CHECK_GE0(avformat_open_input(&input_ctx, FLAGS_i.data(), input_format, NULL));
-        const AVCodec *codec = nullptr;
+        AVCodec *codec = nullptr;
         int video_stream = av_find_best_stream(input_ctx, AVMEDIA_TYPE_VIDEO, -1, -1, &codec, 0);
         DLS_CHECK_GE0(video_stream);
         AVCodecParameters *codecpar = input_ctx->streams[video_stream]->codecpar;


### PR DESCRIPTION
This pull request addresses a type mismatch issue encountered while building DLStreamer from source on a host system following the [Install guide](https://dlstreamer.github.io/get_started/install/install_guide_ubuntu.html#option-3-compile-intel-dl-streamer-pipeline-framework-from-sources-on-host-system) During the `make -j` process, the following error was observed

```
/home/samyak/intel/dlstreamer_gst/samples/ffmpeg_openvino/cpp/decode_inference/decode_inference.cpp:81:87: error: invalid conversion from ‘const AVCodec**’ to ‘AVCodec**’ [-fpermissive]
   81 |         int video_stream = av_find_best_stream(input_ctx, AVMEDIA_TYPE_VIDEO, -1, -1, &codec, 0);
      |                                                                                       ^~~~~~
      |                                                                                       |
      |                                                                                       const AVCodec**
```

Upon reviewing `decode_inference.cpp`, it was identified that `AVCodec *codec` was incorrectly marked as `const`, whereas the `av_find_best_stream` function expects a non-const pointer:

```
int av_find_best_stream(AVFormatContext *ic, AVMediaType type, int wanted_stream_nb,
                        int related_stream, AVCodec **decoder_ret, int flags);
```

This update removes the `const` qualifier from `codec` to match the expected type in the function prototype, thus resolving the type mismatch error and enabling a successful build with `make -j`.